### PR TITLE
Fix lut command file check for non-historic patches

### DIFF
--- a/dotnet/FFXIVDownloader.Command/LutCommand.cs
+++ b/dotnet/FFXIVDownloader.Command/LutCommand.cs
@@ -45,10 +45,11 @@ public class LutCommand
         {
             for (var i = chain.Count - 1; i >= 0; --i)
             {
-                var (ver, patch) = chain[i];
-                if (File.Exists(Path.Join(OutputPath, $"{ver:P}.lut")))
+                var (gameVer, patch) = chain[i];
+                var patchVer = patch.Version;
+                if (File.Exists(Path.Join(OutputPath, $"{patchVer}.lut")))
                 {
-                    Log.Info($"Skipping patch {ver}");
+                    Log.Info($"Skipping patch {patchVer}");
                     chain.RemoveAt(i);
                 }
             }


### PR DESCRIPTION
`FFXIVDownloader.Command`'s lut command currently always regenerates the `.lut` files for non-historic patches, even if the force argument is false, because of a mismatch in which file name is checked for and which is used when writing to the file.

The current check uses `$"{ver:P}.lut"` where `ver` is a `GameVersion` (and the format specifier `:P` appears to do nothing) which doesn't include the prefix `D`, while this is used for the file name further down:
```c#
var patchVer = patch.Version;
// ...
var fileName = $"{patchVer}.lut";
```